### PR TITLE
Inferred implicitly classified by

### DIFF
--- a/annotations/annotations_filter_test.go
+++ b/annotations/annotations_filter_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestLifecycleFilter(t *testing.T) {
 	f := newLifecycleFilter("foo")
-	chain := newAnnotationsFilterChain([]annotationsFilter{f})
+	chain := newAnnotationsFilterChain(f)
 
 	ann := []annotation{
 		{
@@ -26,8 +26,8 @@ func TestLifecycleFilter(t *testing.T) {
 }
 
 func TestDedupFilterPassthrough(t *testing.T) {
-	f := newDedupFilter("baz", "bar")
-	chain := newAnnotationsFilterChain([]annotationsFilter{f})
+	f := defaultDedupFilter
+	chain := newAnnotationsFilterChain(f)
 
 	ann := []annotation{
 		{
@@ -42,74 +42,9 @@ func TestDedupFilterPassthrough(t *testing.T) {
 	assert.Equal(t, ann[0], actual[0], "pass-through predicate")
 }
 
-func TestDedupFilterDropAnnotation(t *testing.T) {
-	f := newDedupFilter("baz", "bar")
-	chain := newAnnotationsFilterChain([]annotationsFilter{f})
-
-	ann := []annotation{
-		{
-			ID: "2",
-			Predicate:"bar",
-		},
-		{
-			ID: "2",
-			Predicate:"baz",
-		},
-	}
-
-	actual := chain.doNext(ann)
-
-	assert.Len(t, actual, 1)
-	assert.Equal(t, ann[1], actual[0], "filtered annotations")
-}
-
-func TestDedupFilterRetainsOtherPredicatesForConcept(t *testing.T) {
-	f := newDedupFilter("baz", "bar")
-	chain := newAnnotationsFilterChain([]annotationsFilter{f})
-
-	ann := []annotation{
-		{
-			ID: "2",
-			Predicate:"foo",
-		},
-		{
-			ID: "2",
-			Predicate:"baz",
-		},
-	}
-
-	actual := chain.doNext(ann)
-
-	assert.Len(t, actual, 2)
-	assert.Contains(t, actual, ann[0])
-	assert.Contains(t, actual, ann[1])
-}
-
-func TestDedupFilterRetainsDifferentConcepts(t *testing.T) {
-	f := newDedupFilter("baz", "bar")
-	chain := newAnnotationsFilterChain([]annotationsFilter{f})
-
-	ann := []annotation{
-		{
-			ID: "2",
-			Predicate:"bar",
-		},
-		{
-			ID: "3",
-			Predicate:"baz",
-		},
-	}
-
-	actual := chain.doNext(ann)
-
-	assert.Len(t, actual, 2)
-	assert.Contains(t, actual, ann[0])
-	assert.Contains(t, actual, ann[1])
-}
-
 func TestDedupFilterDedups(t *testing.T) {
-	f := newDedupFilter("baz", "bar")
-	chain := newAnnotationsFilterChain([]annotationsFilter{f})
+	f := defaultDedupFilter
+	chain := newAnnotationsFilterChain(f)
 
 	ann := []annotation{
 		{

--- a/annotations/annotations_predicate_filter_test.go
+++ b/annotations/annotations_predicate_filter_test.go
@@ -169,7 +169,7 @@ func TestFilterForBasicSingleConcept(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s", test.testDesc), func(t *testing.T) {
 			filter := NewAnnotationsPredicateFilter()
-			chain := newAnnotationsFilterChain([]annotationsFilter{filter})
+			chain := newAnnotationsFilterChain(filter)
 			actualOutput := chain.doNext(test.input)
 
 			By(byUuid).Sort(test.expectedOutput)

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -76,7 +76,7 @@ func (cd cypherDriver) read(contentUUID string) (anns annotations, found bool, e
 			UNION ALL
 			MATCH (content:Thing{uuid:{contentUUID}})-[rel]-(brand:Brand)-[:EQUIVALENT_TO]->(canonicalBrand:Brand)
 			OPTIONAL MATCH (canonicalBrand)-[:EQUIVALENT_TO]-(leafBrand:Brand)-[r:HAS_PARENT*0..]->(parentBrand:Brand)-[:EQUIVALENT_TO]->(canonicalParent:Brand)
-			RETURN distinct coalesce(canonicalParent.prefUUID, parentBrand.uuid) as id, type(rel) as predicate, coalesce(labels(canonicalParent), labels(parentBrand)) as types,
+			RETURN distinct coalesce(canonicalParent.prefUUID, parentBrand.uuid) as id, "IMPLICITLY_CLASSIFIED_BY" as predicate, coalesce(labels(canonicalParent), labels(parentBrand)) as types,
 				coalesce(canonicalParent.prefLabel, parentBrand.prefLabel) as prefLabel, null as leiCode, null as figi, rel.lifecycle as lifecycle
       `,
 		Parameters: neoism.Props{"contentUUID": contentUUID},

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -26,7 +26,6 @@ type cypherDriver struct {
 
 var (
 	pacLifecycleFilter   = newLifecycleFilter(pacLifecycle)
-	pacBrandsDedupFilter = newDedupFilter(predicates["IMPLICITLY_CLASSIFIED_BY"], predicates["IS_CLASSIFIED_BY"])
 )
 
 func NewCypherDriver(conn neoutils.NeoConnection, env string) cypherDriver {
@@ -104,13 +103,15 @@ func (cd cypherDriver) read(contentUUID string) (anns annotations, found bool, e
 		}
 	}
 
-	var chain *annotationsFilterChain
+	var filter annotationsFilter
 	//return  pac lifecycle (tagme) annotations, hide annotations with any other lifcycle or no lifecycle
 	if isLifecyclePresent(pacLifecycle, mappedAnnotations) {
-		chain = newAnnotationsFilterChain([]annotationsFilter{pacLifecycleFilter, pacBrandsDedupFilter})
+		filter = pacLifecycleFilter
 	} else {
-		chain = newAnnotationsFilterChain([]annotationsFilter{NewAnnotationsPredicateFilter()})
+		filter = NewAnnotationsPredicateFilter()
 	}
+
+	chain := newAnnotationsFilterChain(filter)
 	return chain.doNext(mappedAnnotations), found, nil
 }
 

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -66,7 +66,7 @@ var (
 	}
 
 	conceptTypes = map[string][]string{
-		brandType: []string{
+		brandType: {
 			"http://www.ft.com/ontology/core/Thing",
 			"http://www.ft.com/ontology/concept/Concept",
 			"http://www.ft.com/ontology/classification/Classification",
@@ -126,9 +126,9 @@ func (s *cypherDriverTestSuite) TestRetrieveMultipleAnnotations() {
 		getExpectedMallStreetJournalAnnotation(v2Lifecycle, emptyPlatformVersion),
 		getExpectedMetalMickeyAnnotation(v1Lifecycle, emptyPlatformVersion),
 		getExpectedAlphavilleSeriesAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandChildAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandGrandChildAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandParentAnnotation(v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -167,9 +167,9 @@ func (s *cypherDriverTestSuite) TestRetrieveMultipleAnnotationsIfPacAnnotationCa
 		getExpectedMallStreetJournalAnnotation(v2Lifecycle, emptyPlatformVersion),
 		getExpectedMetalMickeyAnnotation(v1Lifecycle, emptyPlatformVersion),
 		getExpectedAlphavilleSeriesAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandChildAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandGrandChildAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandParentAnnotation(v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -187,9 +187,11 @@ func (s *cypherDriverTestSuite) TestRetrieveMultipleAnnotationsIfPacAnnotationCa
 }
 
 func (s *cypherDriverTestSuite) TestRetrieveContentWithParentBrand() {
-	expectedAnnotations := annotations{getExpectedBrandChildAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandParentAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandGrandChildAnnotation(v1Lifecycle, emptyPlatformVersion)}
+	expectedAnnotations := annotations{
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+	}
 
 	driver := NewCypherDriver(s.db, "prod")
 	anns := getAndCheckAnnotations(driver, contentWithParentAndChildBrandUUID, s.T())
@@ -198,9 +200,11 @@ func (s *cypherDriverTestSuite) TestRetrieveContentWithParentBrand() {
 }
 
 func (s *cypherDriverTestSuite) TestRetrieveContentWithGrandParentBrand() {
-	expectedAnnotations := annotations{getExpectedBrandChildAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandParentAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandGrandChildAnnotation(v1Lifecycle, emptyPlatformVersion)}
+	expectedAnnotations := annotations{
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+	}
 
 	driver := NewCypherDriver(s.db, "prod")
 	anns := getAndCheckAnnotations(driver, contentWithThreeLevelsOfBrandUUID, s.T())
@@ -209,8 +213,10 @@ func (s *cypherDriverTestSuite) TestRetrieveContentWithGrandParentBrand() {
 }
 
 func (s *cypherDriverTestSuite) TestRetrieveContentWithCircularBrand() {
-	expectedAnnotations := annotations{getExpectedBrandCircularAAnnotation(v1Lifecycle, emptyPlatformVersion),
-		getExpectedBrandCircularBAnnotation(v1Lifecycle, emptyPlatformVersion)}
+	expectedAnnotations := annotations{
+		expectedAnnotation(brandCircularAUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandCircularBUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+	}
 
 	driver := NewCypherDriver(s.db, "prod")
 	anns := getAndCheckAnnotations(driver, contentWithCircularBrandUUID, s.T())
@@ -219,7 +225,9 @@ func (s *cypherDriverTestSuite) TestRetrieveContentWithCircularBrand() {
 }
 
 func (s *cypherDriverTestSuite) TestRetrieveContentWithJustParentBrand() {
-	expectedAnnotations := annotations{getExpectedBrandParentAnnotation(v1Lifecycle, emptyPlatformVersion)}
+	expectedAnnotations := annotations{
+		expectedAnnotation(brandParentUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+	}
 
 	driver := NewCypherDriver(s.db, "prod")
 	anns := getAndCheckAnnotations(driver, contentWithOnlyFTUUID, s.T())
@@ -230,8 +238,10 @@ func (s *cypherDriverTestSuite) TestRetrieveContentWithJustParentBrand() {
 //Tests filtering Annotations where content is related to Brand A as isClassifiedBy and to Brand B as isPrimarilyClassifiedBy
 // and Brands A and B have a circular relation HasParent
 func (s *cypherDriverTestSuite) TestRetrieveContentBrandsOfDifferentTypes() {
-	expectedAnnotations := annotations{getExpectedBrandCircularAAnnotation(v1Lifecycle, ""),
-		getExpectedBrandCircularBAnnotation(v1Lifecycle, "")}
+	expectedAnnotations := annotations{
+		expectedAnnotation(brandCircularAUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandCircularBUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+	}
 
 	driver := NewCypherDriver(s.db, "prod")
 	anns := getAndCheckAnnotations(driver, contentWithCircularBrandUUID, s.T())
@@ -528,7 +538,8 @@ func getExpectedV1Annotations() annotations {
 	mm.TmeIDs = []string{"TWV0YWwgTWlja2V5-U3ViamVjdHM="}
 	mm.UUIDs = []string{"0483bef8-5797-40b8-9b25-b12e492f63c6"}
 
-	b := getExpectedBrandGrandChildAnnotation(v1Lifecycle, v1PlatformVersion)
+	b := expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, v1PlatformVersion)
+
 	b.TmeIDs = []string{"MTVkNjNmNzctOTA3Mi00GrandChildUtMmI4MGIyODRiNmI0-QnJhbmRz"}
 	b.UUIDs = []string{"ff691bf8-8d92-2a2a-8326-c273400bff0b"}
 
@@ -654,14 +665,6 @@ func getExpectedAlphavilleSeriesAnnotation(lifecycle string, platformVersion str
 	}
 }
 
-func getExpectedBrandParentAnnotation(lifecycle string, platformVersion string) annotation {
-	return expectedAnnotation(brandParentUUID, brandType, predicates["IS_CLASSIFIED_BY"], lifecycle, platformVersion)
-}
-
-func getExpectedBrandChildAnnotation(lifecycle string, platformVersion string) annotation {
-	return expectedAnnotation(brandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], lifecycle, platformVersion)
-}
-
 func expectedAnnotation(conceptUuid string, conceptType string, predicate string, lifecycle string, platformVersion string) annotation {
 	return annotation{
 		Predicate:       predicate,
@@ -672,18 +675,6 @@ func expectedAnnotation(conceptUuid string, conceptType string, predicate string
 		Lifecycle:       lifecycle,
 		PlatformVersion: platformVersion,
 	}
-}
-
-func getExpectedBrandGrandChildAnnotation(lifecycle string, platformVersion string) annotation {
-	return expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], lifecycle, platformVersion)
-}
-
-func getExpectedBrandCircularAAnnotation(lifecycle string, platformVersion string) annotation {
-	return expectedAnnotation(brandCircularAUUID, brandType, predicates["IS_CLASSIFIED_BY"], lifecycle, platformVersion)
-}
-
-func getExpectedBrandCircularBAnnotation(lifecycle string, platformVersion string) annotation {
-	return expectedAnnotation(brandCircularBUUID, brandType, predicates["IS_CLASSIFIED_BY"], lifecycle, platformVersion)
 }
 
 func count(annotationLifecycle string, db neoutils.NeoConnection) (int, error) {


### PR DESCRIPTION
All inferred ancestor brands are now returned with an "implicitlyClassifiedBy" predicate.