### PR TITLE
Adding support on read for implicitAbout annotations

### DIFF
--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -94,7 +94,7 @@ func (cd cypherDriver) read(contentUUID string) (anns annotations, found bool, e
 	err = cd.conn.CypherBatch([]*neoism.CypherQuery{query})
 	end := time.Now()
 
-	log.WithField("duration", fmt.Sprintf("%vms", end.Sub(start).Nanoseconds()/1e6)).Info("Annotations query (including implicit relationships) completed.")
+	log.WithField("contentUUID", contentUUID).WithField("duration", fmt.Sprintf("%vms", end.Sub(start).Nanoseconds()/1e6)).Info("Annotations query (including implicit relationships) completed.")
 
 	if err != nil {
 		log.Errorf("Error looking up uuid %s with query %s from neoism: %+v", contentUUID, query.Statement, err)

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -2,6 +2,7 @@ package annotations
 
 import (
 	"fmt"
+	"time"
 
 	"errors"
 
@@ -89,11 +90,17 @@ func (cd cypherDriver) read(contentUUID string) (anns annotations, found bool, e
 		Result:     &results,
 	}
 
+	start := time.Now()
 	err = cd.conn.CypherBatch([]*neoism.CypherQuery{query})
+	end := time.Now()
+
+	log.Infof("Annotations query (including implicit relationships) completed in [duration=%vms]", end.Sub(start).Nanoseconds()/1e6)
+
 	if err != nil {
 		log.Errorf("Error looking up uuid %s with query %s from neoism: %+v", contentUUID, query.Statement, err)
 		return annotations{}, false, fmt.Errorf("Error accessing Annotations datastore for uuid: %s", contentUUID)
 	}
+
 	log.Debugf("Found %d Annotations for uuid: %s", len(results), contentUUID)
 	if (len(results)) == 0 {
 		return annotations{}, false, nil

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -25,7 +25,7 @@ type cypherDriver struct {
 }
 
 var (
-	pacLifecycleFilter   = newLifecycleFilter(pacLifecycle)
+	pacLifecycleFilter = newLifecycleFilter(pacLifecycle)
 )
 
 func NewCypherDriver(conn neoutils.NeoConnection, env string) cypherDriver {
@@ -72,11 +72,18 @@ func (cd cypherDriver) read(contentUUID string) (anns annotations, found bool, e
 			OPTIONAL MATCH (concept)<-[:ISSUED_BY]-(:FinancialInstrument)<-[:IDENTIFIES]-(figi:FIGIIdentifier)
 			RETURN coalesce(canonicalConcept.prefUUID, concept.uuid) as id, type(rel) as predicate, coalesce(labels(canonicalConcept), labels(concept)) as types,
 				coalesce(canonicalConcept.prefLabel, concept.prefLabel) as prefLabel, lei.value as leiCode, figi.value as figi, rel.lifecycle as lifecycle
-			UNION ALL
+
+      UNION ALL
 			MATCH (content:Thing{uuid:{contentUUID}})-[rel]-(brand:Brand)-[:EQUIVALENT_TO]->(canonicalBrand:Brand)
 			OPTIONAL MATCH (canonicalBrand)-[:EQUIVALENT_TO]-(leafBrand:Brand)-[r:HAS_PARENT*0..]->(parentBrand:Brand)-[:EQUIVALENT_TO]->(canonicalParent:Brand)
 			RETURN distinct coalesce(canonicalParent.prefUUID, parentBrand.uuid) as id, "IMPLICITLY_CLASSIFIED_BY" as predicate, coalesce(labels(canonicalParent), labels(parentBrand)) as types,
 				coalesce(canonicalParent.prefLabel, parentBrand.prefLabel) as prefLabel, null as leiCode, null as figi, rel.lifecycle as lifecycle
+
+      UNION ALL
+      MATCH (content:Thing{uuid:{contentUUID}})-[rel:ABOUT]-(concept:Concept)-[:EQUIVALENT_TO]->(canonicalConcept:Concept)
+      MATCH (canonicalConcept)<-[:EQUIVALENT_TO]-(leafConcept:Concept)-[:HAS_BROADER*1..]->(implicit:Concept)-[:EQUIVALENT_TO]->(canonicalImplicit)
+      WHERE NOT (canonicalImplicit)<-[:EQUIVALENT_TO]-(:Concept)<-[:ABOUT]-(content) // filter out the original abouts
+      RETURN distinct canonicalImplicit.prefUUID as id, "IMPLICITLY_ABOUT" as predicate, labels(canonicalImplicit) as types, canonicalImplicit.prefLabel as prefLabel, null as leiCode, null as figi, rel.lifecycle as lifecycle
       `,
 		Parameters: neoism.Props{"contentUUID": contentUUID},
 		Result:     &results,

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -94,7 +94,7 @@ func (cd cypherDriver) read(contentUUID string) (anns annotations, found bool, e
 	err = cd.conn.CypherBatch([]*neoism.CypherQuery{query})
 	end := time.Now()
 
-	log.Infof("Annotations query (including implicit relationships) completed in [duration=%vms]", end.Sub(start).Nanoseconds()/1e6)
+	log.WithField("duration", fmt.Sprintf("%vms", end.Sub(start).Nanoseconds()/1e6)).Info("Annotations query (including implicit relationships) completed.")
 
 	if err != nil {
 		log.Errorf("Error looking up uuid %s with query %s from neoism: %+v", contentUUID, query.Statement, err)

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -66,17 +66,17 @@ func (cd cypherDriver) read(contentUUID string) (anns annotations, found bool, e
 
 	query := &neoism.CypherQuery{
 		Statement: `
-			MATCH (content:Thing{uuid:{contentUUID}})-[rel]-(concept:Concept)
-			OPTIONAL MATCH (concept)-[:EQUIVALENT_TO]->(canonicalConcept:Concept)
-			OPTIONAL MATCH (concept)<-[:IDENTIFIES]-(lei:LegalEntityIdentifier)
-			OPTIONAL MATCH (concept)<-[:ISSUED_BY]-(:FinancialInstrument)<-[:IDENTIFIES]-(figi:FIGIIdentifier)
-			RETURN coalesce(canonicalConcept.prefUUID, concept.uuid) as id, type(rel) as predicate, coalesce(labels(canonicalConcept), labels(concept)) as types,
+      MATCH (content:Thing{uuid:{contentUUID}})-[rel]-(concept:Concept)
+      OPTIONAL MATCH (concept)-[:EQUIVALENT_TO]->(canonicalConcept:Concept)
+      OPTIONAL MATCH (concept)<-[:IDENTIFIES]-(lei:LegalEntityIdentifier)
+      OPTIONAL MATCH (concept)<-[:ISSUED_BY]-(:FinancialInstrument)<-[:IDENTIFIES]-(figi:FIGIIdentifier)
+      RETURN coalesce(canonicalConcept.prefUUID, concept.uuid) as id, type(rel) as predicate, coalesce(labels(canonicalConcept), labels(concept)) as types,
 				coalesce(canonicalConcept.prefLabel, concept.prefLabel) as prefLabel, lei.value as leiCode, figi.value as figi, rel.lifecycle as lifecycle
 
       UNION ALL
-			MATCH (content:Thing{uuid:{contentUUID}})-[rel]-(brand:Brand)-[:EQUIVALENT_TO]->(canonicalBrand:Brand)
-			OPTIONAL MATCH (canonicalBrand)-[:EQUIVALENT_TO]-(leafBrand:Brand)-[r:HAS_PARENT*0..]->(parentBrand:Brand)-[:EQUIVALENT_TO]->(canonicalParent:Brand)
-			RETURN distinct coalesce(canonicalParent.prefUUID, parentBrand.uuid) as id, "IMPLICITLY_CLASSIFIED_BY" as predicate, coalesce(labels(canonicalParent), labels(parentBrand)) as types,
+      MATCH (content:Thing{uuid:{contentUUID}})-[rel]-(brand:Brand)-[:EQUIVALENT_TO]->(canonicalBrand:Brand)
+      OPTIONAL MATCH (canonicalBrand)-[:EQUIVALENT_TO]-(leafBrand:Brand)-[r:HAS_PARENT*0..]->(parentBrand:Brand)-[:EQUIVALENT_TO]->(canonicalParent:Brand)
+      RETURN distinct coalesce(canonicalParent.prefUUID, parentBrand.uuid) as id, "IMPLICITLY_CLASSIFIED_BY" as predicate, coalesce(labels(canonicalParent), labels(parentBrand)) as types,
 				coalesce(canonicalParent.prefLabel, parentBrand.prefLabel) as prefLabel, null as leiCode, null as figi, rel.lifecycle as lifecycle
 
       UNION ALL

--- a/annotations/fixtures/Annotations-7e22c8b8-b280-4e52-aa22-fa1c6dffd894-cyclic-implicit-abouts.json
+++ b/annotations/fixtures/Annotations-7e22c8b8-b280-4e52-aa22-fa1c6dffd894-cyclic-implicit-abouts.json
@@ -1,0 +1,12 @@
+[
+  {
+    "thing": {
+      "id": "http://api.ft.com/things/7e22c8b8-b280-4e52-aa22-fa1c6dffd894",
+      "prefLabel": "England Ashes 2017 Victory",
+      "types": [
+        "http://www.ft.com/ontology/Topic"
+      ],
+      "predicate": "about"
+    }
+  }
+]

--- a/annotations/fixtures/Annotations-ca982370-66cd-43bd-b2e3-7bfcb73efb1e-implicit-abouts.json
+++ b/annotations/fixtures/Annotations-ca982370-66cd-43bd-b2e3-7bfcb73efb1e-implicit-abouts.json
@@ -1,0 +1,12 @@
+[
+  {
+    "thing": {
+      "id": "http://api.ft.com/things/ca982370-66cd-43bd-b2e3-7bfcb73efb1e",
+      "prefLabel": "Ashes 2017",
+      "types": [
+        "http://www.ft.com/ontology/Topic"
+      ],
+      "predicate": "about"
+    }
+  }
+]

--- a/annotations/fixtures/Topics-77a410a3-6857-4654-80ef-6aae29be852a.json
+++ b/annotations/fixtures/Topics-77a410a3-6857-4654-80ef-6aae29be852a.json
@@ -1,0 +1,24 @@
+{
+  "prefUUID": "77a410a3-6857-4654-80ef-6aae29be852a",
+  "prefLabel": "Dodgy Cyclic Topic B",
+  "type": "Topic",
+  "aliases": [
+    "Dodgy Cyclic Topic B"
+  ],
+  "sourceRepresentations": [
+    {
+      "uuid": "77a410a3-6857-4654-80ef-6aae29be852a",
+      "prefLabel": "Dodgy Cyclic Topic B",
+      "type": "Topic",
+      "authority": "Smartlogic",
+      "authorityValue": "77a410a3-6857-4654-80ef-6aae29be852a",
+      "lastModifiedEpoch": 1507036591,
+      "aliases": [
+        "Dodgy Cyclic Topic B"
+      ],
+      "broaderUUIDs": [
+        "e404e3bd-beff-4324-83f4-beb044baf916"
+      ]
+    }
+  ]
+}

--- a/annotations/fixtures/Topics-7e22c8b8-b280-4e52-aa22-fa1c6dffd894.json
+++ b/annotations/fixtures/Topics-7e22c8b8-b280-4e52-aa22-fa1c6dffd894.json
@@ -1,0 +1,25 @@
+{
+  "prefUUID": "7e22c8b8-b280-4e52-aa22-fa1c6dffd894",
+  "prefLabel": "England Ashes 2017 Victory",
+  "type": "Topic",
+  "aliases": [
+    "England Ashes 2017 Victory"
+  ],
+  "sourceRepresentations": [
+    {
+      "uuid": "7e22c8b8-b280-4e52-aa22-fa1c6dffd894",
+      "prefLabel": "England Ashes 2017 Victory",
+      "type": "Topic",
+      "authority": "Smartlogic",
+      "authorityValue": "7e22c8b8-b280-4e52-aa22-fa1c6dffd894",
+      "lastModifiedEpoch": 1507036591,
+      "aliases": [
+        "England Ashes 2017 Victory"
+      ],
+      "broaderUUIDs": [
+        "ca982370-66cd-43bd-b2e3-7bfcb73efb1e",
+        "77a410a3-6857-4654-80ef-6aae29be852a"
+      ]
+    }
+  ]
+}

--- a/annotations/fixtures/Topics-b6469cc2-f6ff-45aa-a9bb-3d1bb0f9a35d.json
+++ b/annotations/fixtures/Topics-b6469cc2-f6ff-45aa-a9bb-3d1bb0f9a35d.json
@@ -1,0 +1,22 @@
+{
+  "prefUUID": "b6469cc2-f6ff-45aa-a9bb-3d1bb0f9a35d",
+  "prefLabel": "Cricket",
+  "type": "Topic",
+  "aliases": [
+    "Cricket"
+  ],
+  "sourceRepresentations": [
+    {
+      "uuid": "b6469cc2-f6ff-45aa-a9bb-3d1bb0f9a35d",
+      "prefLabel": "Cricket",
+      "type": "Topic",
+      "authority": "Smartlogic",
+      "authorityValue": "b6469cc2-f6ff-45aa-a9bb-3d1bb0f9a35d",
+      "lastModifiedEpoch": 1507036591,
+      "aliases": [
+        "Cricket"
+      ],
+      "broaderUUIDs": []
+    }
+  ]
+}

--- a/annotations/fixtures/Topics-ca982370-66cd-43bd-b2e3-7bfcb73efb1e.json
+++ b/annotations/fixtures/Topics-ca982370-66cd-43bd-b2e3-7bfcb73efb1e.json
@@ -1,0 +1,24 @@
+{
+  "prefUUID": "ca982370-66cd-43bd-b2e3-7bfcb73efb1e",
+  "prefLabel": "Ashes 2017",
+  "type": "Topic",
+  "aliases": [
+    "Ashes 2017"
+  ],
+  "sourceRepresentations": [
+    {
+      "uuid": "ca982370-66cd-43bd-b2e3-7bfcb73efb1e",
+      "prefLabel": "Ashes 2017",
+      "type": "Topic",
+      "authority": "Smartlogic",
+      "authorityValue": "ca982370-66cd-43bd-b2e3-7bfcb73efb1e",
+      "lastModifiedEpoch": 1507036591,
+      "aliases": [
+        "Ashes 2017"
+      ],
+      "broaderUUIDs": [
+        "fde5eee9-3260-4125-adb6-3d91a4888be5"
+      ]
+    }
+  ]
+}

--- a/annotations/fixtures/Topics-e404e3bd-beff-4324-83f4-beb044baf916.json
+++ b/annotations/fixtures/Topics-e404e3bd-beff-4324-83f4-beb044baf916.json
@@ -1,0 +1,24 @@
+{
+  "prefUUID": "e404e3bd-beff-4324-83f4-beb044baf916",
+  "prefLabel": "Dodgy Cyclic Topic A",
+  "type": "Topic",
+  "aliases": [
+    "Dodgy Cyclic Topic A"
+  ],
+  "sourceRepresentations": [
+    {
+      "uuid": "e404e3bd-beff-4324-83f4-beb044baf916",
+      "prefLabel": "Dodgy Cyclic Topic A",
+      "type": "Topic",
+      "authority": "Smartlogic",
+      "authorityValue": "e404e3bd-beff-4324-83f4-beb044baf916",
+      "lastModifiedEpoch": 1507036591,
+      "aliases": [
+        "Dodgy Cyclic Topic A"
+      ],
+      "broaderUUIDs": [
+        "7e22c8b8-b280-4e52-aa22-fa1c6dffd894"
+      ]
+    }
+  ]
+}

--- a/annotations/fixtures/Topics-fde5eee9-3260-4125-adb6-3d91a4888be5.json
+++ b/annotations/fixtures/Topics-fde5eee9-3260-4125-adb6-3d91a4888be5.json
@@ -1,0 +1,24 @@
+{
+  "prefUUID": "fde5eee9-3260-4125-adb6-3d91a4888be5",
+  "prefLabel": "The Ashes",
+  "type": "Topic",
+  "aliases": [
+    "The Ashes"
+  ],
+  "sourceRepresentations": [
+    {
+      "uuid": "fde5eee9-3260-4125-adb6-3d91a4888be5",
+      "prefLabel": "The Ashes",
+      "type": "Topic",
+      "authority": "Smartlogic",
+      "authorityValue": "fde5eee9-3260-4125-adb6-3d91a4888be5",
+      "lastModifiedEpoch": 1507036591,
+      "aliases": [
+        "The Ashes"
+      ],
+      "broaderUUIDs": [
+        "b6469cc2-f6ff-45aa-a9bb-3d1bb0f9a35d"
+      ]
+    }
+  ]
+}

--- a/annotations/models.go
+++ b/annotations/models.go
@@ -29,4 +29,5 @@ var predicates = map[string]string{
 	"IS_CLASSIFIED_BY":           "http://www.ft.com/ontology/classification/isClassifiedBy",
 	"IS_PRIMARILY_CLASSIFIED_BY": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
 	"IMPLICITLY_CLASSIFIED_BY":   "http://www.ft.com/ontology/implicitlyClassifiedBy",
+	"IMPLICITLY_ABOUT":           "http://www.ft.com/ontology/implicitlyAbout",
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -11,7 +11,7 @@
 			"revision": ""
 		},
 		{
-			"checksumSHA1": "aXxnxRchBYOultmFLFv1WcZVPRk=",
+			"checksumSHA1": "JRTXOY4qgGJhOh3AveZBgYz7W3A=",
 			"path": "github.com/Financial-Times/annotations-rw-neo4j/annotations",
 			"revision": "268bf9d5dafad000a07a17517d350fcd8108d473",
 			"revisionTime": "2017-09-18T14:39:07Z",
@@ -19,7 +19,7 @@
 			"versionExact": "2.1.0"
 		},
 		{
-			"checksumSHA1": "6mjazgSyxCKJWzOcNfqHL/T/VWA=",
+			"checksumSHA1": "FfEWrE4sbtmtyeBTHCCF1q3QBxU=",
 			"path": "github.com/Financial-Times/base-ft-rw-app-go/baseftrwapp",
 			"revision": "0800bf5938ecfb4d343ac396117287d289242c8f",
 			"revisionTime": "2017-08-31T12:49:05Z",
@@ -27,7 +27,7 @@
 			"versionExact": "1.0.2"
 		},
 		{
-			"checksumSHA1": "w0Bksn9tOVSuAlO6HQRsOPinwLo=",
+			"checksumSHA1": "i9JURMjjsZfeoAf/wTyw1y0h+5c=",
 			"path": "github.com/Financial-Times/concepts-rw-neo4j/concepts",
 			"revision": "e0170d7608d230f3b6710b19488053e34259120b",
 			"revisionTime": "2017-09-01T10:38:21Z",
@@ -35,7 +35,7 @@
 			"versionExact": "1.1.5"
 		},
 		{
-			"checksumSHA1": "BKT6LPjfYqxRpvVbteL491vS7nw=",
+			"checksumSHA1": "/YiBtiTiT1TVfbfhQGztOo0CtiE=",
 			"path": "github.com/Financial-Times/content-rw-neo4j/content",
 			"revision": "315eb09dc04b493198b76a4a32b0d4b198806c01",
 			"revisionTime": "2017-09-01T14:17:16Z",
@@ -43,7 +43,7 @@
 			"versionExact": "2.0.0"
 		},
 		{
-			"checksumSHA1": "9b1y6Aw3eMMToHyNQ4Qx64LYI+U=",
+			"checksumSHA1": "4EOEpxCej+FHfgPz/I7WRiFaQDQ=",
 			"path": "github.com/Financial-Times/financial-instruments-rw-neo4j/financialinstruments",
 			"revision": "2dd53f7729a145e8e491cf327aa0efdbcf5351bf",
 			"revisionTime": "2017-09-01T11:26:24Z",
@@ -51,19 +51,19 @@
 			"versionExact": "0.0.9"
 		},
 		{
-			"checksumSHA1": "hA3MoSjATaM7AQknoqXcE5skk00=",
+			"checksumSHA1": "fNgRM8ZlaDzdvSpuhSdGxEOrWi4=",
 			"path": "github.com/Financial-Times/go-fthealth/v1_1",
 			"revision": "e7ccca038327a0091303a52445ec1f0fb66cb97b",
 			"revisionTime": "2017-05-25T09:50:41Z"
 		},
 		{
-			"checksumSHA1": "hA3MoSjATaM7AQknoqXcE5skk00=",
+			"checksumSHA1": "fNgRM8ZlaDzdvSpuhSdGxEOrWi4=",
 			"path": "github.com/Financial-Times/go-fthealth/v1_1",
 			"revision": "e7ccca038327a0091303a52445ec1f0fb66cb97b",
 			"revisionTime": "2017-05-25T09:50:41Z"
 		},
 		{
-			"checksumSHA1": "4gy/7n/lgtdi5efuHXwFcIe1ZI8=",
+			"checksumSHA1": "FUhczVSvt/VQAlWfzATo1YLez2E=",
 			"path": "github.com/Financial-Times/go-fthealth/v1a",
 			"revision": "e7ccca038327a0091303a52445ec1f0fb66cb97b",
 			"revisionTime": "2017-05-25T09:50:41Z",
@@ -71,13 +71,13 @@
 			"versionExact": "0.3.0"
 		},
 		{
-			"checksumSHA1": "J21jb1gEj3rsMEzfCyDLRStH6yM=",
+			"checksumSHA1": "R32X8CuDAJV1JimomUEh9SFmc8s=",
 			"path": "github.com/Financial-Times/go-logger",
 			"revision": "83fc3e64dc5506fdb4e56b704949d157a121c76c",
 			"revisionTime": "2017-09-14T08:19:45Z"
 		},
 		{
-			"checksumSHA1": "/xshkhtKNzMRlV2Ud9P0QgH+B4g=",
+			"checksumSHA1": "dqF1g4reeLPNN10qTXgDJj3fHm4=",
 			"path": "github.com/Financial-Times/http-handlers-go/httphandlers",
 			"revision": "229ac16f1d9ec9bca485d2dafb9ec14dc7e9ba24",
 			"revisionTime": "2017-08-09T12:10:07Z",
@@ -85,7 +85,7 @@
 			"versionExact": "0.1.1"
 		},
 		{
-			"checksumSHA1": "G0gakbERWR9IiTLv/7ywoZ7q0OE=",
+			"checksumSHA1": "ZmT6PPQSF7C4aHQ2HO8QsKtYStg=",
 			"path": "github.com/Financial-Times/neo-model-utils-go/mapper",
 			"revision": "1a5407658c842183647f4799bb66ecac73af97a8",
 			"revisionTime": "2017-04-05T08:23:10Z",
@@ -93,7 +93,7 @@
 			"versionExact": "0.2.0"
 		},
 		{
-			"checksumSHA1": "JkENnWGRaRs//sXtyvgvLdh3k9U=",
+			"checksumSHA1": "ibld3tkf8qmEKpF69JI4mrSN0T8=",
 			"path": "github.com/Financial-Times/neo-utils-go/neoutils",
 			"revision": "5cb1750096545b3c8f7384326247e3e30996a905",
 			"revisionTime": "2017-08-22T15:20:35Z",
@@ -101,7 +101,7 @@
 			"versionExact": "1.0.2"
 		},
 		{
-			"checksumSHA1": "R788J8zGaFYX6sWRmn4y5wdLcao=",
+			"checksumSHA1": "OViPZtQxGJ8ECf9BBDvQ112tzP4=",
 			"path": "github.com/Financial-Times/organisations-rw-neo4j/organisations",
 			"revision": "1dce3ba256e3a7e3f5cf1c2a9ebd5091daa6e9b8",
 			"revisionTime": "2017-09-01T15:11:45Z",
@@ -109,7 +109,7 @@
 			"versionExact": "0.5.9"
 		},
 		{
-			"checksumSHA1": "9+9fICMYU4aSDLl81hP6dfZ2wWk=",
+			"checksumSHA1": "/wxgSLJ/9Qo+nm/YTRSxbUTh8jM=",
 			"path": "github.com/Financial-Times/people-rw-neo4j/people",
 			"revision": "02e3fd84a717dc8359d54c8eecba46c33c7ecd5c",
 			"revisionTime": "2017-09-01T15:57:34Z",
@@ -117,19 +117,19 @@
 			"versionExact": "2.0.0"
 		},
 		{
-			"checksumSHA1": "lQfsRf7gWYQDNoI3IOZuwNGUwRo=",
+			"checksumSHA1": "fqpohN7Qp2qj7TLMbUxh/cK4oH0=",
 			"path": "github.com/Financial-Times/service-status-go/buildinfo",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "7QAsTdXi/6nTkDhqKy54YIc69d4=",
+			"checksumSHA1": "2rGNLXdRC3qr5n5ll7BpYt8HCK8=",
 			"path": "github.com/Financial-Times/service-status-go/gtg",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "YxgjuCI4TJyfQujUeQk3V+gypzo=",
+			"checksumSHA1": "973POGyMCoyaKQuIYX2f7EKFwlQ=",
 			"path": "github.com/Financial-Times/service-status-go/httphandlers",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z",
@@ -137,43 +137,43 @@
 			"versionExact": "0.1.0"
 		},
 		{
-			"checksumSHA1": "+Lyl4SYSRLQ7Hz2MNJlGKsmXL+8=",
+			"checksumSHA1": "+sjiZBzrsk91W1A3Md1azCkZadg=",
 			"path": "github.com/Financial-Times/transactionid-utils-go",
 			"revision": "df2f00c734957c9dd651ce23ab0e0902504c7636",
 			"revisionTime": "2017-03-28T16:39:54Z"
 		},
 		{
-			"checksumSHA1": "cQ26ZjI71lDGYOwY9+VprRY4PHI=",
+			"checksumSHA1": "diw1KueSVzsMHPCNDvj+xQiXSTE=",
 			"path": "github.com/Financial-Times/up-rw-app-api-go/rwapi",
 			"revision": "d9d93a1f689538313d12fee6f5f10715cfe280e0",
 			"revisionTime": "2017-07-10T12:58:28Z"
 		},
 		{
-			"checksumSHA1": "guo63XdLn1n7MtawdVcICjFNNBI=",
+			"checksumSHA1": "/6H1rhQmbq8mEP29pnmLmdwBKUE=",
 			"path": "github.com/cyberdelia/go-metrics-graphite",
 			"revision": "39f87cc3b432bbb898d7c643c0e93cac2bc865ad",
 			"revisionTime": "2016-12-19T23:08:53Z"
 		},
 		{
-			"checksumSHA1": "GcIrB1ug6mS8aG73v1KtlHfva9Q=",
+			"checksumSHA1": "mrz/kicZiUaHxkyfvC/DyQcr8Do=",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "a476722483882dd40b8111f0eb64e1d7f43f56e4",
 			"revisionTime": "2017-08-29T19:49:58Z"
 		},
 		{
-			"checksumSHA1": "IkPM2QLv9urri7S49wzroQx9oXA=",
+			"checksumSHA1": "g/V4qrXjUGG9B+e3hB+4NAYJ5Gs=",
 			"path": "github.com/gorilla/context",
 			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
 			"revisionTime": "2016-08-17T18:46:32Z"
 		},
 		{
-			"checksumSHA1": "4OqsCtUfKO1c0KlmlgS4JBt3g4E=",
+			"checksumSHA1": "/lWfaq/Ok+El1amGaf3wPY5JpUc=",
 			"path": "github.com/gorilla/handlers",
 			"revision": "a4d79d4487c2430a17d9dc8a1f74d1a6ed6908ca",
 			"revisionTime": "2017-06-02T15:16:48Z"
 		},
 		{
-			"checksumSHA1": "pH3ilCit1CH+Skv2N16IxHgje4A=",
+			"checksumSHA1": "Ow/mLkfVIZgMOXE6aPSdPiDLJ6c=",
 			"path": "github.com/gorilla/mux",
 			"revision": "bcd8bc72b08df0f70df986b97f95590779502d31",
 			"revisionTime": "2017-05-21T04:50:13Z",
@@ -181,13 +181,13 @@
 			"versionExact": "v1.4.0"
 		},
 		{
-			"checksumSHA1": "KJqRW8jfPoHquMAd6FI7x92JxFs=",
+			"checksumSHA1": "tUGxc7rfX0cmhOOUDhMuAZ9rWsA=",
 			"path": "github.com/hashicorp/go-version",
 			"revision": "03c5bf6be031b6dd45afec16b1cf94fc8938bc77",
 			"revisionTime": "2017-02-02T08:07:59Z"
 		},
 		{
-			"checksumSHA1": "uEp3WSlpTPjeOSMLHs5C96psK2g=",
+			"checksumSHA1": "I7AAXZqD3Dy5KjQ9N+2/iHzlKzc=",
 			"path": "github.com/jawher/mow.cli",
 			"revision": "a459d5906bb7a9c5eda7c4d02eec7c541120226e",
 			"revisionTime": "2017-08-20T16:57:35Z",
@@ -195,73 +195,73 @@
 			"versionExact": "v1.0.1"
 		},
 		{
-			"checksumSHA1": "gVGl3skHHlqE+JFBqC7Vs6phjpg=",
+			"checksumSHA1": "nMm7xgpbpYYWy/zdKttNSoo1HAE=",
 			"path": "github.com/jmcvetta/neoism",
 			"revision": "4674154f870d19b356581843f481dccd6792dcc0",
 			"revisionTime": "2017-03-06T10:41:37Z"
 		},
 		{
-			"checksumSHA1": "QD46tPMRlsF6qRy3lUmC0ZCCo1A=",
+			"checksumSHA1": "khL6oKjx81rAZKW+36050b7f5As=",
 			"path": "github.com/jmcvetta/randutil",
 			"revision": "2bb1b664bcff821e02b2a0644cd29c7e824d54f8",
 			"revisionTime": "2015-08-17T12:26:01Z"
 		},
 		{
-			"checksumSHA1": "LslpZwP8HemFrj4JNJCAekwzl48=",
+			"checksumSHA1": "Zi5uRKslwVUdr2KUweC0F0h9q2A=",
 			"path": "github.com/joho/godotenv",
 			"revision": "c9360df4d16dc0e391ea2f28da2d31a9ede2e26f",
 			"revisionTime": "2017-08-22T04:21:26Z"
 		},
 		{
-			"checksumSHA1": "6ZVvq9gdocZXtsQpVPcQWWmZIf8=",
+			"checksumSHA1": "UE4lhbPYYWEhqHXQk24OA73m5+8=",
 			"path": "github.com/joho/godotenv/autoload",
 			"revision": "c9360df4d16dc0e391ea2f28da2d31a9ede2e26f",
 			"revisionTime": "2017-08-22T04:21:26Z"
 		},
 		{
-			"checksumSHA1": "ZbvybRLthm+bve1duASQ5ghFl6Y=",
+			"checksumSHA1": "eOXF2PEvYLMeD8DSzLZJWbjYzco=",
 			"path": "github.com/kr/pretty",
 			"revision": "cfb55aafdaf3ec08f0db22699ab822c50091b1c4",
 			"revisionTime": "2016-08-23T17:07:15Z"
 		},
 		{
-			"checksumSHA1": "OdjJhBQQtNpITIPc6X+C9e/6RLw=",
+			"checksumSHA1": "uulQHQ7IsRKqDudBC8Go9J0gtAc=",
 			"path": "github.com/kr/text",
 			"revision": "7cafcd837844e784b526369c9bce262804aebc60",
 			"revisionTime": "2016-05-04T02:26:26Z"
 		},
 		{
-			"checksumSHA1": "R3yk3OJzuq4MVfVGX5AhkkYv1ko=",
+			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
 			"revisionTime": "2016-01-10T10:55:54Z"
 		},
 		{
-			"checksumSHA1": "DIjooF5+DLH5JSOjqnBlfNh9dFU=",
+			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
 			"path": "github.com/rcrowley/go-metrics",
 			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "t5W90J4d7vhrs6+LDp0BalvCZEU=",
+			"checksumSHA1": "BYvROBsiyAXK4sq6yhDe8RgT4LM=",
 			"path": "github.com/sirupsen/logrus",
 			"revision": "89742aefa4b206dcf400792f3bd35b542998eb3b",
 			"revisionTime": "2017-08-22T13:27:46Z"
 		},
 		{
-			"checksumSHA1": "bEYPw3QRqpj0ID7Q2FAr0xnF1Xw=",
+			"checksumSHA1": "Kt+BhrXMyYvOc9TGiBVOSNn6wcc=",
 			"path": "github.com/sirupsen/logrus/hooks/test",
 			"revision": "89742aefa4b206dcf400792f3bd35b542998eb3b",
 			"revisionTime": "2017-08-22T13:27:46Z"
 		},
 		{
-			"checksumSHA1": "DI0VKPtBaDl+Hg2UcZU3SZb+U54=",
+			"checksumSHA1": "jAzqolwnRJhHsKXmmvKNrHqxqAw=",
 			"path": "github.com/spaolacci/murmur3",
 			"revision": "9f5d223c60793748f04a9d5b4b4eacddfc1f755d",
 			"revisionTime": "2017-08-19T07:11:01Z"
 		},
 		{
-			"checksumSHA1": "3fuOD4+Q7k/yYdaklodK+6njEm0=",
+			"checksumSHA1": "q1qqfgDOGwfEuMlbHWNjYf09ACM=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
 			"revisionTime": "2016-09-25T01:54:16Z",
@@ -269,7 +269,7 @@
 			"versionExact": "v1.1.4"
 		},
 		{
-			"checksumSHA1": "ijg28hsp/vqFRrJnicpz0AdSIFk=",
+			"checksumSHA1": "P9FJpir2c4G5PA46qEkaWy3l60U=",
 			"path": "github.com/stretchr/testify/require",
 			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
 			"revisionTime": "2016-09-25T01:54:16Z",
@@ -277,7 +277,7 @@
 			"versionExact": "v1.1.4"
 		},
 		{
-			"checksumSHA1": "DYSpN7qnGi7YtLv17YIh7HvM1wQ=",
+			"checksumSHA1": "wE2g522VLUmwlEnTBtUSZhY6ex4=",
 			"path": "github.com/stretchr/testify/suite",
 			"revision": "69483b4bd14f5845b5a1e55bca19e954e827f1d0",
 			"revisionTime": "2016-09-25T01:54:16Z",
@@ -285,13 +285,13 @@
 			"versionExact": "v1.1.4"
 		},
 		{
-			"checksumSHA1": "G9ZGa1NLkstgPd9EylK9Hq+wqrE=",
+			"checksumSHA1": "0FCBLTqGOxgifAKfS0360iLTZR4=",
 			"path": "github.com/ugorji/go/codec",
 			"revision": "8c0409fcbb70099c748d71f714529204975f6c3f",
 			"revisionTime": "2017-08-26T15:59:43Z"
 		},
 		{
-			"checksumSHA1": "jzagU1HfylQH/eBE9u9MrpkVHw8=",
+			"checksumSHA1": "dBmk68coq8umF51FL23vNXOOS7o=",
 			"path": "go4.org/osutil",
 			"revision": "034d17a462f7b2dcd1a4a73553ec5357ff6e6c6e",
 			"revisionTime": "2017-05-24T23:16:39Z"
@@ -309,7 +309,7 @@
 			"revisionTime": "2016-09-14T00:11:54Z"
 		},
 		{
-			"checksumSHA1": "6Yh/sh2D/OyNxKqPVs8alWUhTms=",
+			"checksumSHA1": "w70GrQt8nhjc6j0i3rEZjWuSpKY=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "7ddbeae9ae08c6a06a59597f0c9edbc5ff2444ce",
 			"revisionTime": "2017-09-01T16:16:44Z"
@@ -321,7 +321,7 @@
 			"revisionTime": "2017-09-01T16:16:44Z"
 		},
 		{
-			"checksumSHA1": "o6bET16IF+7+f1w7B/JNyIIYzak=",
+			"checksumSHA1": "k3L1Q7anlDsX2njPAE5Dd2SWVlw=",
 			"path": "gopkg.in/jmcvetta/napping.v3",
 			"revision": "4c7b4b235c63152afa9a1c6384e708e0fbfd77ca",
 			"revisionTime": "2017-03-11T05:32:04Z"


### PR DESCRIPTION
NOTE! The only change to the query is the last `UNION ALL` statement, the rest is just noise (/ whitespace formatting)

Tests cover:
* Narrower implicit annotations are not returned
* Cyclic `hasBroader` relationships do not break the service
* The original `about` is never incorrectly returned as an `implicitAbout`.
