### PR TITLE
Remove platformVersion filtering endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,43 +45,6 @@ only the annotation with "About" relationship will be returned.
 Similarly if a piece of content is annotated with a Concept "Is Classified By" and "Is Primarily Classified By"
 only the annotation with "Is Primarily Classified By" relationship will be returned.
 
-### GET content/{uuid}/annotations/{platformVersion} endpoint
-
-This endpoint returns all the existing annotations for a specific platformVersion - if any.
-Note:
-The response here is an enriched format of the simple /content/{uuid}/annotations response, containing fields like `platformVersion`, and the referenced concepts' identifiers.
-This endpoint does not show inferred Brands annotations, as the other endpoint does.
-
-### Response Example
-The structure of the the response is the same both endpoints and would look like this:
-```
-[...
-    {
-        predicate: "http://www.ft.com/ontology/classification/isClassifiedBy",
-        id: "http://api.ft.com/things/{concepts_canonical_uuid}",
-        apiUrl: "http://api.ft.com/things/{concepts_canonical_uuid}",
-        types: [
-            "http://www.ft.com/ontology/core/Thing",
-            "http://www.ft.com/ontology/concept/Concept",
-            "http://www.ft.com/ontology/classification/Classification",
-            "http://www.ft.com/ontology/Subject"
-        ],
-        prefLabel: "Company News",
-        leiCode: "leicode_value",
-        FIGI: "figi_value",
-        factsetID: "factsetID_value"
-        tmeIDs: [
-            "tmeid__value"
-        ],
-        uuids: [
-            "uuid1","uuid2","canonical_uuid"
-        ],
-        platformVersion: "v1",
-    },
-...
-]
-```
-
 ## Admin endpoints
 
 Healthchecks: [http://localhost:8080/__health](http://localhost:8080/__health)  

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -15,7 +15,6 @@ import (
 // Driver interface
 type driver interface {
 	read(id string) (anns annotations, found bool, err error)
-	filteredRead(id string, platformVersion string) (anns annotations, found bool, err error)
 	checkConnectivity() error
 }
 
@@ -129,59 +128,6 @@ func (cd cypherDriver) read(contentUUID string) (anns annotations, found bool, e
 	return chain.doNext(mappedAnnotations), found, nil
 }
 
-// Returns all the annotations with the specified platformVersion enriched with all the existing concept IDs for a given content
-func (cd cypherDriver) filteredRead(contentUUID string, platformVersion string) (anns annotations, found bool, err error) {
-	results := []neoAnnotation{}
-
-	query := &neoism.CypherQuery{
-		Statement: `
-			MATCH (content:Thing{uuid:{contentUUID}})-[rel{platformVersion:{platformVersion}}]->(concept:Concept)
-			OPTIONAL MATCH (concept)-[:EQUIVALENT_TO]->(canonicalConcept:Concept)
-			OPTIONAL MATCH (canonicalConcept)<-[:EQUIVALENT_TO]-(leafConcepts:Concept)
-			OPTIONAL MATCH (concept)<-[:IDENTIFIES]-(lei:LegalEntityIdentifier)
-			OPTIONAL MATCH (concept)<-[:ISSUED_BY]-(:FinancialInstrument)<-[:IDENTIFIES]-(figi:FIGIIdentifier)
-			OPTIONAL MATCH (concept)<-[:IDENTIFIES]-(tme:TMEIdentifier)
-			OPTIONAL MATCH (concept)<-[:IDENTIFIES]-(fs:FactsetIdentifier)
-			OPTIONAL MATCH (concept)<-[:IDENTIFIES]-(upp:UPPIdentifier)
-			OPTIONAL MATCH (leafConcepts)<-[:IDENTIFIES]-(sourceUPP:UPPIdentifier)
-			OPTIONAL MATCH (leafConcepts)<-[:IDENTIFIES]-(sourceLEI:LegalEntityIdentifier)
-			OPTIONAL MATCH (leafConcepts)<-[:IDENTIFIES]-(sourceTME:TMEIdentifier)
-			OPTIONAL MATCH (leafConcepts)<-[:IDENTIFIES]-(sourceFS:FactsetIdentifier)
-			WITH concept, canonicalConcept, rel, figi, lei, collect(distinct fs.value) + collect(distinct sourceFS.value) as fs, collect(distinct tme.value) + collect(distinct sourceTME.value) as tme, collect(distinct upp.value) + collect(distinct sourceUPP.value) as upp
-			RETURN coalesce(canonicalConcept.prefUUID, concept.uuid) as id, type(rel) as predicate, coalesce(labels(canonicalConcept), labels(concept)) as types,
-				coalesce(canonicalConcept.prefLabel, concept.prefLabel) as prefLabel, {platformVersion} as platformVersion, lei.value as leiCode, figi.value as figi, rel.lifecycle as lifecycle, tme as tmeIDs, fs as factsetID, upp as uuids
-			`,
-		Parameters: neoism.Props{"contentUUID": contentUUID, "platformVersion": platformVersion},
-		Result:     &results,
-	}
-
-	err = cd.conn.CypherBatch([]*neoism.CypherQuery{query})
-	if err != nil {
-		log.Errorf("Error looking up uuid %s with query %s from neoism: %+v", contentUUID, query.Statement, err)
-		return annotations{}, false, fmt.Errorf("Error accessing Annotations datastore for uuid: %s", contentUUID)
-	}
-	log.Debugf("Found %d Annotations for uuid: %s with platformVersion: %s", len(results), contentUUID, platformVersion)
-	if (len(results)) == 0 {
-		return annotations{}, false, nil
-	}
-
-	mappedAnnotations := []annotation{}
-
-	found = false
-
-	for _, ann := range results {
-		if ann.ID != "" {
-			annotation, err := mapToResponseFormat(ann, cd.env)
-			if err == nil {
-				mappedAnnotations = append(mappedAnnotations, annotation)
-				found = true
-			}
-		}
-	}
-
-	return mappedAnnotations, found, nil
-}
-
 func mapToResponseFormat(neoAnn neoAnnotation, env string) (annotation, error) {
 	var ann annotation
 
@@ -203,19 +149,8 @@ func mapToResponseFormat(neoAnn neoAnnotation, env string) (annotation, error) {
 		return ann, err
 	}
 	ann.Predicate = predicate
-
-	ann.PlatformVersion = neoAnn.PlatformVersion
 	ann.Lifecycle = neoAnn.Lifecycle
 
-	if len(neoAnn.TmeIDs) > 0 {
-		ann.TmeIDs = deduplicateList(neoAnn.TmeIDs)
-	}
-	if len(neoAnn.FactsetIDs) > 0 {
-		ann.FactsetIDs = deduplicateList(neoAnn.FactsetIDs)
-	}
-	if len(neoAnn.UUIDs) > 0 {
-		ann.UUIDs = deduplicateList(neoAnn.UUIDs)
-	}
 	return ann, nil
 }
 

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -153,9 +153,9 @@ func (s *cypherDriverTestSuite) TestRetrieveMultipleAnnotations() {
 		getExpectedMallStreetJournalAnnotation(v2Lifecycle, emptyPlatformVersion),
 		getExpectedMetalMickeyAnnotation(v1Lifecycle, emptyPlatformVersion),
 		getExpectedAlphavilleSeriesAnnotation(v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -169,9 +169,9 @@ func (s *cypherDriverTestSuite) TestRetrievePacAnnotationsAsPriority() {
 		getExpectedMetalMickeyAnnotation(pacLifecycle, emptyPlatformVersion),
 		getExpectedFacebookAnnotation(pacLifecycle, emptyPlatformVersion),
 		getExpectedJohnSmithAnnotation(pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], pacLifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], pacLifecycle),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], pacLifecycle),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], pacLifecycle),
 	}
 	driver := NewCypherDriver(s.db, "prod")
 	writePacAnnotations(s.T(), s.db)
@@ -190,9 +190,9 @@ func (s *cypherDriverTestSuite) TestRetrievePacAnnotationsAsPriority() {
 
 func (s *cypherDriverTestSuite) TestRetrieveImplicitAbouts() {
 	expectedAnnotations := annotations{
-		expectedAnnotation(aboutTopic, topicType, predicates["ABOUT"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(broaderTopicA, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(broaderTopicB, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle, emptyPlatformVersion),
+		expectedAnnotation(aboutTopic, topicType, predicates["ABOUT"], pacLifecycle),
+		expectedAnnotation(broaderTopicA, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle),
+		expectedAnnotation(broaderTopicB, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -206,12 +206,12 @@ func (s *cypherDriverTestSuite) TestRetrieveImplicitAbouts() {
 
 func (s *cypherDriverTestSuite) TestRetrieveCyclicImplicitAbouts() {
 	expectedAnnotations := annotations{
-		expectedAnnotation(narrowerTopic, topicType, predicates["ABOUT"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(aboutTopic, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(broaderTopicA, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(broaderTopicB, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(cyclicTopicA, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle, emptyPlatformVersion),
-		expectedAnnotation(cyclicTopicB, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle, emptyPlatformVersion),
+		expectedAnnotation(narrowerTopic, topicType, predicates["ABOUT"], pacLifecycle),
+		expectedAnnotation(aboutTopic, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle),
+		expectedAnnotation(broaderTopicA, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle),
+		expectedAnnotation(broaderTopicB, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle),
+		expectedAnnotation(cyclicTopicA, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle),
+		expectedAnnotation(cyclicTopicB, topicType, predicates["IMPLICITLY_ABOUT"], pacLifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -231,9 +231,9 @@ func (s *cypherDriverTestSuite) TestRetrieveMultipleAnnotationsIfPacAnnotationCa
 		getExpectedMallStreetJournalAnnotation(v2Lifecycle, emptyPlatformVersion),
 		getExpectedMetalMickeyAnnotation(v1Lifecycle, emptyPlatformVersion),
 		getExpectedAlphavilleSeriesAnnotation(v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -252,9 +252,9 @@ func (s *cypherDriverTestSuite) TestRetrieveMultipleAnnotationsIfPacAnnotationCa
 
 func (s *cypherDriverTestSuite) TestRetrieveContentWithParentBrand() {
 	expectedAnnotations := annotations{
-		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -265,9 +265,9 @@ func (s *cypherDriverTestSuite) TestRetrieveContentWithParentBrand() {
 
 func (s *cypherDriverTestSuite) TestRetrieveContentWithGrandParentBrand() {
 	expectedAnnotations := annotations{
-		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -278,8 +278,8 @@ func (s *cypherDriverTestSuite) TestRetrieveContentWithGrandParentBrand() {
 
 func (s *cypherDriverTestSuite) TestRetrieveContentWithCircularBrand() {
 	expectedAnnotations := annotations{
-		expectedAnnotation(brandCircularAUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandCircularBUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandCircularAUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandCircularBUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -290,7 +290,7 @@ func (s *cypherDriverTestSuite) TestRetrieveContentWithCircularBrand() {
 
 func (s *cypherDriverTestSuite) TestRetrieveContentWithJustParentBrand() {
 	expectedAnnotations := annotations{
-		expectedAnnotation(brandParentUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
@@ -303,40 +303,14 @@ func (s *cypherDriverTestSuite) TestRetrieveContentWithJustParentBrand() {
 // and Brands A and B have a circular relation HasParent
 func (s *cypherDriverTestSuite) TestRetrieveContentBrandsOfDifferentTypes() {
 	expectedAnnotations := annotations{
-		expectedAnnotation(brandCircularAUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
-		expectedAnnotation(brandCircularBUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle, emptyPlatformVersion),
+		expectedAnnotation(brandCircularAUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle),
+		expectedAnnotation(brandCircularBUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], v1Lifecycle),
 	}
 
 	driver := NewCypherDriver(s.db, "prod")
 	anns := getAndCheckAnnotations(driver, contentWithCircularBrandUUID, s.T())
 	assert.Equal(s.T(), len(expectedAnnotations), len(anns), "Didn't get the same number of annotations")
 	assertListContainsAll(s.T(), anns, expectedAnnotations)
-}
-
-func (s *cypherDriverTestSuite) TestRetrieveMultipleV1Annotations() {
-	expectedAnnotations := getExpectedV1Annotations()
-	driver := NewCypherDriver(s.db, "prod")
-	anns := getAndCheckFilteredAnnotations(driver, contentUUID, "v1", s.T())
-	assert.Equal(s.T(), len(expectedAnnotations), len(anns), "Didn't get the same number of annotations")
-	assertListContainsAll(s.T(), anns, expectedAnnotations)
-
-	for _, ann := range anns {
-		log.Info(ann)
-		assert.Equal(s.T(), "v1", ann.PlatformVersion)
-	}
-}
-
-func (s *cypherDriverTestSuite) TestRetrieveMultipleV2Annotations() {
-	expectedAnnotations := getExpectedV2Annotations()
-	driver := NewCypherDriver(s.db, "prod")
-	anns := getAndCheckFilteredAnnotations(driver, contentUUID, "v2", s.T())
-	assert.Equal(s.T(), len(expectedAnnotations), len(anns), "Didn't get the same number of annotations")
-	assertListContainsAll(s.T(), anns, expectedAnnotations)
-
-	for _, ann := range anns {
-		log.Info(ann)
-		assert.Equal(s.T(), "v2", ann.PlatformVersion)
-	}
 }
 
 func TestRetrieveNoAnnotationsWhenThereAreNonePresentExceptBrands(t *testing.T) {
@@ -405,13 +379,6 @@ func TestRetrieveNoAnnotationsWhenThereAreNoConceptsPresent(t *testing.T) {
 
 func getAndCheckAnnotations(driver cypherDriver, contentUUID string, t *testing.T) annotations {
 	anns, found, err := driver.read(contentUUID)
-	assert.NoError(t, err, "Unexpected error for content %s", contentUUID)
-	assert.True(t, found, "Found no annotations for content %s", contentUUID)
-	return anns
-}
-
-func getAndCheckFilteredAnnotations(driver cypherDriver, contentUUID string, platformVersion string, t *testing.T) annotations {
-	anns, found, err := driver.filteredRead(contentUUID, platformVersion)
 	assert.NoError(t, err, "Unexpected error for content %s", contentUUID)
 	assert.True(t, found, "Found no annotations for content %s", contentUUID)
 	return anns
@@ -618,37 +585,6 @@ func cleanDB(t testing.TB, db neoutils.NeoConnection) {
 	assert.NoError(t, err)
 }
 
-func getExpectedV1Annotations() annotations {
-
-	av := getExpectedAlphavilleSeriesAnnotation(v1Lifecycle, v1PlatformVersion)
-	av.TmeIDs = []string{"FOOBAR"}
-	av.UUIDs = []string{"747894f8-a231-4efb-805d-753635eca712"}
-
-	mm := getExpectedMetalMickeyAnnotation(v1Lifecycle, v1PlatformVersion)
-	mm.TmeIDs = []string{"TWV0YWwgTWlja2V5-U3ViamVjdHM="}
-	mm.UUIDs = []string{"0483bef8-5797-40b8-9b25-b12e492f63c6"}
-
-	b := expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], v1Lifecycle, v1PlatformVersion)
-
-	b.TmeIDs = []string{"MTVkNjNmNzctOTA3Mi00GrandChildUtMmI4MGIyODRiNmI0-QnJhbmRz"}
-	b.UUIDs = []string{"ff691bf8-8d92-2a2a-8326-c273400bff0b"}
-
-	return []annotation{av, mm, b}
-}
-
-func getExpectedV2Annotations() annotations {
-
-	fb := getExpectedFakebookAnnotation(v2Lifecycle, v2PlatformVersion)
-	fb.FactsetIDs = []string{"00AAA-E"}
-	fb.UUIDs = []string{"eac853f5-3859-4c08-8540-55e043719400"}
-
-	msj := getExpectedMallStreetJournalAnnotation(v2Lifecycle, v2PlatformVersion)
-	msj.FactsetIDs = []string{"00BBBB-E"}
-	msj.UUIDs = []string{"5d1510f8-2779-4b74-adab-0a5eb138fca6"}
-
-	return []annotation{fb, msj}
-}
-
 func getExpectedFakebookAnnotation(lifecycle string, platformVersion string) annotation {
 	return annotation{
 		Predicate: "http://www.ft.com/ontology/annotation/mentions",
@@ -661,11 +597,10 @@ func getExpectedFakebookAnnotation(lifecycle string, platformVersion string) ann
 			"http://www.ft.com/ontology/company/Company",
 			"http://www.ft.com/ontology/company/PublicCompany",
 		},
-		LeiCode:         "BQ4BKCS1HXDV9TTTTTTTT",
-		FIGI:            "BB8000C3P0-R2D2",
-		PrefLabel:       "Fakebook, Inc.",
-		Lifecycle:       lifecycle,
-		PlatformVersion: platformVersion,
+		LeiCode:   "BQ4BKCS1HXDV9TTTTTTTT",
+		FIGI:      "BB8000C3P0-R2D2",
+		PrefLabel: "Fakebook, Inc.",
+		Lifecycle: lifecycle,
 	}
 }
 
@@ -679,9 +614,8 @@ func getExpectedMallStreetJournalAnnotation(lifecycle string, platformVersion st
 			"http://www.ft.com/ontology/concept/Concept",
 			"http://www.ft.com/ontology/organisation/Organisation",
 		},
-		PrefLabel:       "The Mall Street Journal",
-		Lifecycle:       lifecycle,
-		PlatformVersion: platformVersion,
+		PrefLabel: "The Mall Street Journal",
+		Lifecycle: lifecycle,
 	}
 }
 
@@ -696,9 +630,8 @@ func getExpectedMetalMickeyAnnotation(lifecycle string, platformVersion string) 
 			"http://www.ft.com/ontology/classification/Classification",
 			"http://www.ft.com/ontology/Subject",
 		},
-		PrefLabel:       "Metal Mickey",
-		Lifecycle:       lifecycle,
-		PlatformVersion: platformVersion,
+		PrefLabel: "Metal Mickey",
+		Lifecycle: lifecycle,
 	}
 }
 
@@ -714,11 +647,10 @@ func getExpectedFacebookAnnotation(lifecycle string, platformVersion string) ann
 			"http://www.ft.com/ontology/company/Company",
 			"http://www.ft.com/ontology/company/PublicCompany",
 		},
-		PrefLabel:       "Fakebook, Inc.",
-		Lifecycle:       lifecycle,
-		PlatformVersion: platformVersion,
-		LeiCode:         "BQ4BKCS1HXDV9TTTTTTTT",
-		FIGI:            "BB8000C3P0-R2D2",
+		PrefLabel: "Fakebook, Inc.",
+		Lifecycle: lifecycle,
+		LeiCode:   "BQ4BKCS1HXDV9TTTTTTTT",
+		FIGI:      "BB8000C3P0-R2D2",
 	}
 }
 
@@ -732,9 +664,8 @@ func getExpectedJohnSmithAnnotation(lifecycle string, platformVersion string) an
 			"http://www.ft.com/ontology/concept/Concept",
 			"http://www.ft.com/ontology/person/Person",
 		},
-		PrefLabel:       "John Smith",
-		Lifecycle:       lifecycle,
-		PlatformVersion: platformVersion,
+		PrefLabel: "John Smith",
+		Lifecycle: lifecycle,
 	}
 }
 
@@ -749,21 +680,19 @@ func getExpectedAlphavilleSeriesAnnotation(lifecycle string, platformVersion str
 			"http://www.ft.com/ontology/classification/Classification",
 			"http://www.ft.com/ontology/AlphavilleSeries",
 		},
-		PrefLabel:       "Test Alphaville Series",
-		Lifecycle:       lifecycle,
-		PlatformVersion: platformVersion,
+		PrefLabel: "Test Alphaville Series",
+		Lifecycle: lifecycle,
 	}
 }
 
-func expectedAnnotation(conceptUuid string, conceptType string, predicate string, lifecycle string, platformVersion string) annotation {
+func expectedAnnotation(conceptUuid string, conceptType string, predicate string, lifecycle string) annotation {
 	return annotation{
-		Predicate:       predicate,
-		ID:              fmt.Sprintf("http://api.ft.com/things/%s", conceptUuid),
-		APIURL:          fmt.Sprintf(conceptApiUrlTemplates[conceptType], conceptUuid),
-		Types:           conceptTypes[conceptType],
-		PrefLabel:       conceptLabels[conceptUuid],
-		Lifecycle:       lifecycle,
-		PlatformVersion: platformVersion,
+		Predicate: predicate,
+		ID:        fmt.Sprintf("http://api.ft.com/things/%s", conceptUuid),
+		APIURL:    fmt.Sprintf(conceptApiUrlTemplates[conceptType], conceptUuid),
+		Types:     conceptTypes[conceptType],
+		PrefLabel: conceptLabels[conceptUuid],
+		Lifecycle: lifecycle,
 	}
 }
 

--- a/annotations/handlers.go
+++ b/annotations/handlers.go
@@ -51,37 +51,3 @@ func GetAnnotations(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(msg))
 	}
 }
-
-func GetFilteredAnnotations(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	uuid := vars["uuid"]
-	platformVersion := vars["platformVersion"]
-
-	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
-	if uuid == "" {
-		http.Error(w, "uuid required", http.StatusBadRequest)
-		return
-	}
-	annotations, found, err := AnnotationsDriver.filteredRead(uuid, platformVersion)
-	if err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		msg := fmt.Sprintf(`{"message":"Error getting annotations for content with uuid %s for platformVersion %s, err=%s"}`, uuid, platformVersion, err.Error())
-		w.Write([]byte(msg))
-		return
-	}
-	if !found {
-		w.WriteHeader(http.StatusNotFound)
-		msg := fmt.Sprintf(`{"message":"No annotations found for content with uuid %s for platformVersion %s."}`, uuid, platformVersion)
-		w.Write([]byte(msg))
-		return
-	}
-
-	w.Header().Set("Cache-Control", CacheControlHeader)
-	w.WriteHeader(http.StatusOK)
-
-	if err = json.NewEncoder(w).Encode(annotations); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		msg := fmt.Sprintf(`{"message":"Error parsing annotations for content with uuid %s for platformVersion %s, err=%s"}`, uuid, platformVersion, err.Error())
-		w.Write([]byte(msg))
-	}
-}

--- a/annotations/handlers_test.go
+++ b/annotations/handlers_test.go
@@ -30,9 +30,6 @@ func TestGetHandler(t *testing.T) {
 		{"Success", newRequest("GET", fmt.Sprintf("/content/%s/annotations", knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
 		{"NotFound", newRequest("GET", fmt.Sprintf("/content/%s/annotations", "99999"), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusNotFound, "", message("No annotations found for content with uuid 99999.")},
 		{"ReadError", newRequest("GET", fmt.Sprintf("/content/%s/annotations", knownUUID), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusServiceUnavailable, "", message("Error getting annotations for content with uuid 12345, err=TEST failing to READ")},
-		{"Success", newRequest("GET", fmt.Sprintf("/content/%s/annotations/%s", knownUUID, platformVersion), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusOK, "", "[]"},
-		{"NotFound", newRequest("GET", fmt.Sprintf("/content/%s/annotations/%s", "99999", platformVersion), "application/json", nil), dummyService{contentUUID: knownUUID}, http.StatusNotFound, "", message(fmt.Sprintf("No annotations found for content with uuid 99999 for platformVersion %s.", platformVersion))},
-		{"ReadError", newRequest("GET", fmt.Sprintf("/content/%s/annotations/%s", knownUUID, platformVersion), "application/json", nil), dummyService{contentUUID: knownUUID, failRead: true}, http.StatusServiceUnavailable, "", message(fmt.Sprintf("Error getting annotations for content with uuid 12345 for platformVersion %s, err=TEST failing to READ", platformVersion))},
 	}
 
 	for _, test := range tests {
@@ -40,7 +37,6 @@ func TestGetHandler(t *testing.T) {
 		rec := httptest.NewRecorder()
 		r := mux.NewRouter()
 		r.HandleFunc("/content/{uuid}/annotations", GetAnnotations).Methods("GET")
-		r.HandleFunc("/content/{uuid}/annotations/{platformVersion}", GetFilteredAnnotations).Methods("GET")
 		r.ServeHTTP(rec, test.req)
 		assert.True(t, test.statusCode == rec.Code, fmt.Sprintf("%s: Wrong response code, was %d, should be %d", test.name, rec.Code, test.statusCode))
 		assert.JSONEq(t, test.body, rec.Body.String(), fmt.Sprintf("%s: Wrong body", test.name))
@@ -57,7 +53,6 @@ func TestMethodeNotFound(t *testing.T) {
 		rec := httptest.NewRecorder()
 		r := mux.NewRouter()
 		r.HandleFunc("/content/{uuid}/annotations", GetAnnotations).Methods("GET")
-		r.HandleFunc("/content/{uuid}/annotations/{platformVersion}", GetFilteredAnnotations).Methods("GET")
 		r.ServeHTTP(rec, test.req)
 		assert.True(t, test.statusCode == rec.Code, fmt.Sprintf("%s: Wrong response code, was %d, should be %d", test.name, rec.Code, test.statusCode))
 		assert.Equal(t, test.body, rec.Body.String(), fmt.Sprintf("%s: Wrong body", test.name))
@@ -84,16 +79,6 @@ type dummyService struct {
 }
 
 func (dS dummyService) read(contentUUID string) (annotations, bool, error) {
-	if dS.failRead {
-		return nil, false, errors.New("TEST failing to READ")
-	}
-	if contentUUID == dS.contentUUID {
-		return []annotation{}, true, nil
-	}
-	return nil, false, nil
-}
-
-func (dS dummyService) filteredRead(contentUUID string, platformVersion string) (annotations, bool, error) {
 	if dS.failRead {
 		return nil, false, errors.New("TEST failing to READ")
 	}

--- a/annotations/models.go
+++ b/annotations/models.go
@@ -10,11 +10,6 @@ type annotation struct {
 	LeiCode   string   `json:"leiCode,omitempty"`
 	FIGI      string   `json:"FIGI,omitempty"`
 	PrefLabel string   `json:"prefLabel,omitempty"`
-	//the fields below are populated only for the /content/{uuid}/annotations/{plaformVersion} endpoint
-	FactsetIDs      []string `json:"factsetIDs,omitempty"`
-	TmeIDs          []string `json:"tmeIDs,omitempty"`
-	UUIDs           []string `json:"uuids,omitempty"`
-	PlatformVersion string   `json:"platformVersion,omitempty"`
 	//used for filtering, e.g. pac not exposed
 	Lifecycle string `json:"-"`
 }

--- a/app.go
+++ b/app.go
@@ -141,7 +141,6 @@ func routeRequests(port string) {
 	servicesRouter := mux.NewRouter()
 
 	servicesRouter.HandleFunc("/content/{uuid}/annotations", annotations.GetAnnotations).Methods("GET")
-	servicesRouter.HandleFunc("/content/{uuid}/annotations/{platformVersion}", annotations.GetFilteredAnnotations).Methods("GET")
 	servicesRouter.HandleFunc("/content/{uuid}/annotations", annotations.MethodNotAllowedHandler)
 
 	var monitoringRouter http.Handler = servicesRouter


### PR DESCRIPTION
Since we modified the post-publication-combiner functionality (no longer gets the TME ids for annotations from this service), the filtering endpoint can be decommissioned. 