### PR TITLE
Adding shared context instead of env vars in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,16 @@ workflows:
           name: build-and-test-project
           executor-name:
             name: ft-golang-ci/default-with-neo4j
+          context: cm-team-github
       - ft-golang-ci/docker-build:
           name: build-docker-image
           requires:
             - build-and-test-project
+          context: cm-team-github
   snyk-scanning:
     jobs:
       - ft-golang-ci/scan:
           name: scan-dependencies
-          context: cm-team-snyk
+          context: 
+            - cm-team-snyk
+            - cm-team-github


### PR DESCRIPTION
# Description

## What

Adding shared context instead of env vars in circleci config. Rotating COVERALLS_TOKEN.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4143)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
