### PR TITLE
Feature/uppsf 4229 use bookmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
           name: build-and-test-project
           executor-name:
             name: ft-golang-ci/default-with-neo4j
+            neo4j-image-version: 4.4-enterprise
           context: cm-team-github
       - ft-golang-ci/docker-build:
           name: build-docker-image
@@ -20,6 +21,6 @@ workflows:
     jobs:
       - ft-golang-ci/scan:
           name: scan-dependencies
-          context: 
+          context:
             - cm-team-snyk
             - cm-team-github

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Mention here sections of code which you would like reviewers to pay extra attent
 
 _Would appreciate a second pair of eyes on the test_  
 _I am not quite sure how this bit works_  
-_Is there a better library for doing x_  
+_Is there a better library for doing x_
 
 ## Scope and particulars of this PR (Please tick all that apply)
 
@@ -24,6 +24,17 @@ _Is there a better library for doing x_
 - [ ] Documentation
 - [ ] Breaking change
 - [ ] Minor change (e.g. fixing a typo, adding config)
+
+## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"
+
+- [ ] Test coverage is not significantly decreased
+- [ ] All PR checks have passed
+- [ ] Changes are deployed on dev before asking for review
+- [ ] Documentation remains up-to-date
+    - [ ] OpenAPI definition file is updated
+    - [ ] README file is updated
+    - [ ] Documentation is updated in upp-docs and upp-public-docs
+    - [ ] Architecture diagrams are updated
 
 ___
 This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)

--- a/_ft/api.yml
+++ b/_ft/api.yml
@@ -22,9 +22,10 @@ paths:
     get:
       summary: Retrieves the annotations for a piece of content.
       description:
-        Given UUID of some content as a path parameter, responds with the
-        annotations of the requested piece of content in json format.
-        If any of the concepts used in the annotations is deprecated the response will contain \"isDeprecated:true\" for that concept.
+        Given UUID of some content as a path parameter, responds with the annotations of the requested piece of content 
+        in json format. If any of the concepts used in the annotations is deprecated the response will contain 
+        \"isDeprecated:true\" for that concept. If Neo4j-Bookmarks header is provided the read request will happen from
+        Neo4j instance up to date to the point represented by the bookmark.
       tags:
         - Public API
       parameters:
@@ -35,8 +36,8 @@ paths:
           example: 59439611-a23a-38ae-8615-b35a80d4e6f1
           schema:
             type: string
-        - name: lifecycle
-          in: query
+        - in: query
+          name: lifecycle
           required: false
           schema:
             type: array
@@ -47,6 +48,11 @@ paths:
                 - v1
                 - pac
                 - v2
+        - in: header
+          name: Neo4j-Bookmark
+          schema:
+            type: string
+          required: false
       responses:
         "200":
           description: Returns the annotations if they exists.

--- a/annotations/handlers.go
+++ b/annotations/handlers.go
@@ -9,6 +9,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const Neo4jBookmarkHeader = "Neo4j-Bookmark"
+
 // HandlerCtx contains objects needed from the annotations http handlers and is being passed to them as param
 type HandlerCtx struct {
 	AnnotationsDriver  driver
@@ -34,6 +36,8 @@ func GetAnnotations(hctx *HandlerCtx) func(http.ResponseWriter, *http.Request) {
 		vars := mux.Vars(r)
 		uuid := vars["uuid"]
 
+		bookmark := r.Header.Get(Neo4jBookmarkHeader)
+
 		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 		if uuid == "" {
 			http.Error(w, "uuid required", http.StatusBadRequest)
@@ -57,7 +61,7 @@ func GetAnnotations(hctx *HandlerCtx) func(http.ResponseWriter, *http.Request) {
 			}
 		}
 
-		annotations, found, err := hctx.AnnotationsDriver.read(uuid)
+		annotations, found, err := hctx.AnnotationsDriver.read(uuid, bookmark)
 		if err != nil {
 			hctx.Log.WithError(err).WithUUID(uuid).Error("failed getting annotations for content")
 			writeResponseError(hctx, w, http.StatusServiceUnavailable, uuid, `{"message":"Error getting annotations for content with uuid %s"}`)

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - neo4j
   neo4j:
-    image: neo4j:4.3.6-enterprise
+    image: neo4j:4.4-enterprise
     environment:
           NEO4J_AUTH: none
           NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"


### PR DESCRIPTION
# Description

## What

Allow parsing a header of annotations GET request which contains a Neo4j bookmark.
Use the parsed bookmark if available when reading from Neo4j. That guarantees that the instance of the db that handles the read transaction is at least up to date to the point represented by the bookmark.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4229

## Anything, in particular, you'd like to highlight to reviewers

_The integration tests are run in a single instance instead of cluster. In order for them to work consistently in a cluster, bookmarks should be returned on the write operations of the integrations tests which is not doable in the current set up. So the integration tests are left on single instance._  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
