### PR TITLE
Fix the url for hasReference predicate

### DIFF
--- a/annotations/models.go
+++ b/annotations/models.go
@@ -31,7 +31,7 @@ var predicates = map[string]string{
 	"HAS_AUTHOR":                 "http://www.ft.com/ontology/annotation/hasAuthor",
 	"HAS_CONTRIBUTOR":            "http://www.ft.com/ontology/hasContributor",
 	"HAS_DISPLAY_TAG":            "http://www.ft.com/ontology/hasDisplayTag",
-	"HAS_REFERENCE":              "http://www.ft.com/ontology/hasReference",
+	"HAS_REFERENCE":              "http://www.ft.com/ontology/annotation/hasReference",
 	"IS_CLASSIFIED_BY":           "http://www.ft.com/ontology/classification/isClassifiedBy",
 	"HAS_BRAND":                  "http://www.ft.com/ontology/classification/isClassifiedBy",
 	"IS_PRIMARILY_CLASSIFIED_BY": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",


### PR DESCRIPTION
# Description

## What

The url returned by the api for the has reference predicate was inconsistent with the one used for publishing.

## Why

[UPPSF-5003](https://financialtimes.atlassian.net/browse/UPPSF-5003)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [X] Test coverage is not significantly decreased
- [X] All PR checks have passed
- [X] Changes are deployed on dev before asking for review
- [X] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-5003]: https://financialtimes.atlassian.net/browse/UPPSF-5003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ