### PR TITLE
Uppsf 5396 add publication filter

### DIFF
--- a/_ft/api.yml
+++ b/_ft/api.yml
@@ -55,6 +55,11 @@ paths:
             type: array
             items:
               type: string
+        - in: query
+          name: showPublication
+          required: false
+          schema:
+            type: boolean
         - in: header
           name: Neo4j-Bookmark
           schema:

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -754,7 +754,37 @@ func (s *cypherDriverTestSuite) TestRetrieveAnnotationsWithPublicationFTPink() {
 	writeManualAnnotations(s.T(), s.driver)
 
 	annotationsDriver := NewCypherDriver(s.driver, publicAPIURL)
-	publicationFilter := newPublicationFilter(withPublication([]string{ftPink}))
+	publicationFilter := newPublicationFilter(withPublication([]string{ftPink}, true))
+	filters := []annotationsFilter{publicationFilter}
+	anns := getAndCheckAnnotationsWithSpecificFilters(annotationsDriver, contentUUID, s.T(), filters...)
+
+	expectedAnnotations := Annotations{
+		getExpectedMetalMickeyAnnotation(pacLifecycle),
+		getExpectedHasDisplayTagFakebookAnnotation(pacLifecycle),
+		getExpectedAboutFakebookAnnotation(pacLifecycle),
+		getExpectedJohnSmithAnnotation(pacLifecycle),
+		getExpectedMallStreetJournalAnnotation(),
+		expectedAnnotation(brandGrandChildUUID, brandType, predicates["IS_CLASSIFIED_BY"], pacLifecycle),
+		expectedAnnotation(brandChildUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], pacLifecycle),
+		expectedAnnotation(brandParentUUID, brandType, predicates["IMPLICITLY_CLASSIFIED_BY"], pacLifecycle),
+	}
+
+	for i := range expectedAnnotations {
+		if expectedAnnotations[i].Lifecycle != v2Lifecycle {
+			expectedAnnotations[i].Publication = []string{ftPink}
+		}
+	}
+
+	assert.Len(s.T(), anns, len(expectedAnnotations), "Didn't get the same number of annotations")
+	assertListContainsAll(s.T(), anns, expectedAnnotations)
+}
+
+func (s *cypherDriverTestSuite) TestRetrieveAnnotationsWithEmptyPublicationFilter() {
+	writePacAnnotations(s.T(), s.driver, []interface{}{ftPink})
+	writeManualAnnotations(s.T(), s.driver)
+
+	annotationsDriver := NewCypherDriver(s.driver, publicAPIURL)
+	publicationFilter := newPublicationFilter(withPublication([]string{}, true))
 	filters := []annotationsFilter{publicationFilter}
 	anns := getAndCheckAnnotationsWithSpecificFilters(annotationsDriver, contentUUID, s.T(), filters...)
 
@@ -784,7 +814,7 @@ func (s *cypherDriverTestSuite) TestRetrieveAnnotationsWithoutPublicationAndFTPi
 	writeManualAnnotations(s.T(), s.driver)
 
 	annotationsDriver := NewCypherDriver(s.driver, publicAPIURL)
-	publicationFilter := newPublicationFilter(withPublication([]string{ftPink}))
+	publicationFilter := newPublicationFilter(withPublication([]string{ftPink}, true))
 	filters := []annotationsFilter{publicationFilter}
 	anns := getAndCheckAnnotationsWithSpecificFilters(annotationsDriver, contentUUID, s.T(), filters...)
 
@@ -808,7 +838,7 @@ func (s *cypherDriverTestSuite) TestRetrieveAnnotationsWithPublicationSV() {
 	writeManualAnnotations(s.T(), s.driver)
 
 	annotationsDriver := NewCypherDriver(s.driver, publicAPIURL)
-	publicationFilter := newPublicationFilter(withPublication([]string{sv}))
+	publicationFilter := newPublicationFilter(withPublication([]string{sv}, true))
 	filters := []annotationsFilter{publicationFilter}
 	anns := getAndCheckAnnotationsWithSpecificFilters(annotationsDriver, contentUUID, s.T(), filters...)
 
@@ -818,6 +848,23 @@ func (s *cypherDriverTestSuite) TestRetrieveAnnotationsWithPublicationSV() {
 
 	for i := range expectedAnnotations {
 		expectedAnnotations[i].Publication = []string{sv}
+	}
+
+	assert.Len(s.T(), anns, len(expectedAnnotations), "Didn't get the same number of annotations")
+	assertListContainsAll(s.T(), anns, expectedAnnotations)
+}
+
+func (s *cypherDriverTestSuite) TestRetrieveAnnotationsWithPublicationSVAndRemovedPublicationFromResponse() {
+	writePacAnnotations(s.T(), s.driver, []interface{}{ftPink})
+	writeManualAnnotations(s.T(), s.driver)
+
+	annotationsDriver := NewCypherDriver(s.driver, publicAPIURL)
+	publicationFilter := newPublicationFilter(withPublication([]string{sv}, false))
+	filters := []annotationsFilter{publicationFilter}
+	anns := getAndCheckAnnotationsWithSpecificFilters(annotationsDriver, contentUUID, s.T(), filters...)
+
+	expectedAnnotations := Annotations{
+		getExpectedAboutFakebookAnnotation(lifecycleMap["manual"]),
 	}
 
 	assert.Len(s.T(), anns, len(expectedAnnotations), "Didn't get the same number of annotations")

--- a/annotations/handlers.go
+++ b/annotations/handlers.go
@@ -79,7 +79,11 @@ func GetAnnotations(hctx *HandlerCtx) func(http.ResponseWriter, *http.Request) {
 		if showPublicationParam := params.Get("showPublication"); showPublicationParam != "" {
 			showPublication, err = strconv.ParseBool(showPublicationParam)
 			if err != nil {
-				writeResponseError(hctx, w, http.StatusBadRequest, uuid, `{"message":"showPublication query parameter is not a boolean"}`)
+				w.WriteHeader(http.StatusBadRequest)
+				msg := `{"message":"showPublication query parameter is not a boolean"}`
+				if _, err = w.Write([]byte(msg)); err != nil {
+					hctx.Log.WithError(err).Errorf("Error while writing response: %s", msg)
+				}
 				return
 			}
 		}

--- a/annotations/handlers.go
+++ b/annotations/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/Financial-Times/go-logger/v2"
 	"github.com/gorilla/mux"
@@ -74,7 +75,15 @@ func GetAnnotations(hctx *HandlerCtx) func(http.ResponseWriter, *http.Request) {
 
 		lifecycleFilter := newLifecycleFilter(withLifecycles(lifecycleParams))
 		predicateFilter := NewAnnotationsPredicateFilter()
-		publicationFilter := newPublicationFilter(withPublication(params["publication"]))
+		showPublication := false
+		if showPublicationParam := params.Get("showPublication"); showPublicationParam != "" {
+			showPublication, err = strconv.ParseBool(showPublicationParam)
+			if err != nil {
+				writeResponseError(hctx, w, http.StatusBadRequest, uuid, `{"message":"showPublication query parameter is not a boolean"}`)
+				return
+			}
+		}
+		publicationFilter := newPublicationFilter(withPublication(params["publication"], showPublication))
 		chain := newAnnotationsFilterChain(lifecycleFilter, predicateFilter, publicationFilter)
 
 		annotations = chain.doNext(annotations)

--- a/annotations/publication_filter.go
+++ b/annotations/publication_filter.go
@@ -1,8 +1,6 @@
 package annotations
 
-import (
-	"slices"
-)
+import "slices"
 
 const (
 	ftPink = "88fdde6c-2aa4-4f78-af02-9f680097cfd6"
@@ -34,23 +32,24 @@ func (f *publicationFilter) filter(in []Annotation, chain *annotationsFilterChai
 }
 
 func (f *publicationFilter) filterByPublication(annotations []Annotation) []Annotation {
-	if len(f.publication) == 0 {
-		return annotations
-	}
-
 	var filtered []Annotation
-	for _, annotation := range annotations {
-		for _, pub := range f.publication {
-			if slices.Contains(annotation.Publication, pub) {
-				filtered = append(filtered, annotation)
-			}
 
-			if pub == ftPink {
-				if annotation.Publication == nil {
+	if len(f.publication) > 0 {
+		for _, annotation := range annotations {
+			for _, pub := range f.publication {
+				if slices.Contains(annotation.Publication, pub) {
 					filtered = append(filtered, annotation)
+				}
+	
+				if pub == ftPink {
+					if annotation.Publication == nil {
+						filtered = append(filtered, annotation)
+					}
 				}
 			}
 		}
+	} else {
+		filtered = annotations
 	}
 
 	if !f.showPublication {

--- a/annotations/publication_filter.go
+++ b/annotations/publication_filter.go
@@ -40,7 +40,7 @@ func (f *publicationFilter) filterByPublication(annotations []Annotation) []Anno
 				if slices.Contains(annotation.Publication, pub) {
 					filtered = append(filtered, annotation)
 				}
-	
+
 				if pub == ftPink {
 					if annotation.Publication == nil {
 						filtered = append(filtered, annotation)
@@ -52,11 +52,15 @@ func (f *publicationFilter) filterByPublication(annotations []Annotation) []Anno
 		filtered = annotations
 	}
 
+	f.applyShowPublicationFilter(filtered)
+
+	return filtered
+}
+
+func (f *publicationFilter) applyShowPublicationFilter(filtered []Annotation) {
 	if !f.showPublication {
 		for i := range filtered {
 			filtered[i].Publication = nil
 		}
 	}
-
-	return filtered
 }

--- a/annotations/publication_filter.go
+++ b/annotations/publication_filter.go
@@ -9,7 +9,8 @@ const (
 )
 
 type publicationFilter struct {
-	publication []string
+	publication     []string
+	showPublication bool
 }
 
 func newPublicationFilter(opts ...func(*publicationFilter)) *publicationFilter {
@@ -21,8 +22,9 @@ func newPublicationFilter(opts ...func(*publicationFilter)) *publicationFilter {
 	return &pf
 }
 
-func withPublication(publication []string) func(filter *publicationFilter) {
+func withPublication(publication []string, showPublication bool) func(filter *publicationFilter) {
 	return func(f *publicationFilter) {
+		f.showPublication = showPublication
 		f.publication = publication
 	}
 }
@@ -48,6 +50,12 @@ func (f *publicationFilter) filterByPublication(annotations []Annotation) []Anno
 					filtered = append(filtered, annotation)
 				}
 			}
+		}
+	}
+
+	if !f.showPublication {
+		for i := range filtered {
+			filtered[i].Publication = nil
 		}
 	}
 

--- a/annotations/publication_filter_test.go
+++ b/annotations/publication_filter_test.go
@@ -65,7 +65,7 @@ func TestPublicationFiltering(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			annotations := []Annotation{annotationA, annotationB, annotationC, annotationD}
-			f := newPublicationFilter(withPublication(tc.publication))
+			f := newPublicationFilter(withPublication(tc.publication, true))
 			chain := newAnnotationsFilterChain(f)
 			filtered := chain.doNext(annotations)
 


### PR DESCRIPTION
# Description

## What

in order to apply policy control for draft-annotations-api delete endpoint we would need the publication to be returned and applied a filter where you can use showPublication=true as a query param.

## Why

Copy (if there is one) the text of the original Trello/JIRA ticket in here, with a link back to it for the curious.

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [ ] Documentation remains up-to-date
    - [ ] OpenAPI definition file is updated
    - [ ] README file is updated
    - [ ] Documentation is updated in upp-docs and upp-public-docs
    - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
